### PR TITLE
feat: set sql syntax

### DIFF
--- a/sql-formatter.py
+++ b/sql-formatter.py
@@ -1,11 +1,21 @@
 import sublime
 import sublime_plugin
+import os
 
-from .src import formatter
+from .src import formatter, preferences
 
 
 class SqlFormatterCommand(sublime_plugin.TextCommand):
     def run(self, edit, **kwargs):  # pylint: disable=arguments-differ
+        self.syntax_to_sql()
+        self.format(edit, **kwargs)
+
+    def syntax_to_sql(self):
+        syntax = os.path.splitext(os.path.basename(self.view.settings().get("syntax")))[0]
+        if syntax.lower() != "sql" and preferences.get_pref('set_syntax_on_format'):
+            self.view.set_syntax_file("Packages/SQL/SQL.sublime-syntax")
+
+    def format(self, edit, **kwargs):
         full_file_region = sublime.Region(0, self.view.size())
         file_text = self.view.substr(full_file_region)
         formatted_text = formatter.format_sql(file_text, kwargs['dialect'] if kwargs else None)

--- a/sql-formatter.sublime-settings
+++ b/sql-formatter.sublime-settings
@@ -18,5 +18,8 @@
 	"indent_size": 2,
 
 	// Indent with tabs instead of spaces
-	"use_tabs": false
+	"use_tabs": false,
+
+    // set syntax
+    "set_syntax_on_format": true
 }


### PR DESCRIPTION
I often create a new tab in Sublime Text and paste SQL queries to format them. However, the new file is not labeled as SQL syntax, resulting in no syntax highlighting for the formatted result. So I created this feature.